### PR TITLE
fixed issue with 2xx > than 200

### DIFF
--- a/middleware/_example/go.mod
+++ b/middleware/_example/go.mod
@@ -9,7 +9,7 @@ go 1.21.0
 
 require (
 	github.com/gin-gonic/gin v1.9.1
-	github.com/twistingmercury/telemetry v0.0.0-00010101000000-000000000000
+	github.com/twistingmercury/telemetry v0.9.0
 	github.com/twistingmercury/telemetry/middleware/gin v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.26.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.26.0

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -88,37 +88,37 @@ func Telemetry(attribs attributes.Attributes) gonic.HandlerFunc {
 // SpanStatus returns the OpenTelemetry status code as defined in
 // go.opentelemetry.io/old_elemetry/codes and a brief description for a given HTTP status code.
 func SpanStatus(status int) (code otelCodes.Code, desc string) {
-	switch status {
-	case 200:
+	switch {
+	case status >= 200 && status < 300:
 		code = otelCodes.Ok
 		desc = "OK"
-	case 400:
+	case status == 400:
 		code = otelCodes.Ok
 		desc = "Bad Request"
-	case 401:
+	case status == 401:
 		code = otelCodes.Ok
 		desc = "Unauthorized"
-	case 403:
+	case status == 403:
 		code = otelCodes.Ok
 		desc = "Forbidden"
-	case 404:
+	case status == 404:
 		code = otelCodes.Ok
 		desc = "Not Found"
-	case 405:
+	case status == 405:
 		code = otelCodes.Ok
 		desc = "Method Not Allowed"
-	case 500:
+	case status == 500:
 		code = otelCodes.Error
 		desc = "Internal Server Error"
-	case 502:
+	case status == 502:
 		code = otelCodes.Error
 		desc = "Bad Gateway"
-	case 503:
+	case status == 503:
 		code = otelCodes.Error
 		desc = "Service Unavailable"
 	default:
-		code = otelCodes.Error
-		desc = "Unknown"
+		code = otelCodes.Unset
+		desc = ""
 	}
 	return
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -219,7 +219,7 @@ func TestSpanStatus(t *testing.T) {
 			expected: struct {
 				code codes.Code
 				desc string
-			}{code: codes.Error, desc: "Unknown"},
+			}{code: codes.Unset, desc: ""},
 		},
 	}
 


### PR DESCRIPTION
An error in the func `SpanStatus` treated all 2xx statuses other than 200 as an error. This fix was to check if the status was in the 2xx range then set the default to `Unset`